### PR TITLE
Handle case where the view is not present in the current view

### DIFF
--- a/screencaptor/src/main/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessor.kt
+++ b/screencaptor/src/main/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessor.kt
@@ -1,0 +1,46 @@
+package com.wealthfront.screencaptor.views.modifier
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import java.lang.IllegalArgumentException
+
+internal class DefaultViewDataProcessor : ViewDataProcessor {
+
+  override fun modifyViews(view: View, viewDataModifiers: Set<DataModifier>): Set<DataModifier> {
+    val listOfInitialStateModifier = mutableSetOf<DataModifier>()
+    viewDataModifiers.forEach { modifier ->
+      val initialStateModifier: DataModifier
+      when (modifier) {
+        is TextViewDataModifier -> {
+          val textView = view.findViewById<TextView>(modifier.id)
+          textView?.let {
+            initialStateModifier = TextViewDataModifier(modifier.id, textView.text)
+            textView.text = modifier.data
+            listOfInitialStateModifier.add(initialStateModifier)
+          }
+        }
+        is ImageViewDataModifier -> {
+          val imageView = view.findViewById<ImageView>(modifier.id)
+          imageView?.let {
+            initialStateModifier = ImageViewDataModifier(modifier.id, imageView.drawable)
+            imageView.setImageDrawable(modifier.data)
+            listOfInitialStateModifier.add(initialStateModifier)
+          }
+        }
+        else -> throw IllegalArgumentException("Unhandled modifier: ${modifier::class}. " +
+            "Please provide a custom ViewDataProcessor if you want to handle this modifier")
+      }
+    }
+    return listOfInitialStateModifier
+  }
+
+  override fun resetViews(view: View, initialDataModifiers: Set<DataModifier>) {
+    initialDataModifiers.forEach { modifier ->
+      when (modifier) {
+        is TextViewDataModifier -> view.findViewById<TextView>(modifier.id).text = modifier.data
+        is ImageViewDataModifier -> view.findViewById<ImageView>(modifier.id).setImageDrawable(modifier.data)
+      }
+    }
+  }
+}

--- a/screencaptor/src/main/java/com/wealthfront/screencaptor/views/modifier/ViewDataProcessor.kt
+++ b/screencaptor/src/main/java/com/wealthfront/screencaptor/views/modifier/ViewDataProcessor.kt
@@ -6,42 +6,9 @@ import android.widget.ImageView
 import android.widget.TextView
 import java.lang.IllegalArgumentException
 
-internal class DefaultViewDataProcessor : ViewDataProcessor {
-
-  override fun modifyViews(view: View, viewDataModifiers: Set<DataModifier>): Set<DataModifier> {
-    val listOfInitialStateModifier = mutableSetOf<DataModifier>()
-    viewDataModifiers.forEach { modifier ->
-      val initialStateModifier: DataModifier
-      when (modifier) {
-        is TextViewDataModifier -> {
-          val textView = view.findViewById<TextView>(modifier.id)
-          initialStateModifier = TextViewDataModifier(modifier.id, textView.text)
-          textView.text = modifier.data
-          listOfInitialStateModifier.add(initialStateModifier)
-        }
-        is ImageViewDataModifier -> {
-          val imageView = view.findViewById<ImageView>(modifier.id)
-          initialStateModifier = ImageViewDataModifier(modifier.id, imageView.drawable)
-          imageView.setImageDrawable(modifier.data)
-          listOfInitialStateModifier.add(initialStateModifier)
-        }
-        else -> throw IllegalArgumentException("Unhandled modifier: ${modifier::class}. " +
-            "Please provide a custom ViewDataProcessor if you want to handle this modifier")
-      }
-    }
-    return listOfInitialStateModifier
-  }
-
-  override fun resetViews(view: View, initialDataModifiers: Set<DataModifier>) {
-    initialDataModifiers.forEach { modifier ->
-      when (modifier) {
-        is TextViewDataModifier -> view.findViewById<TextView>(modifier.id).text = modifier.data
-        is ImageViewDataModifier -> view.findViewById<ImageView>(modifier.id).setImageDrawable(modifier.data)
-      }
-    }
-  }
-}
-
+/**
+ * This provides the ability to supply sample data for the screenshots and various implementation of the [DataModifier].
+ */
 interface ViewDataProcessor {
   fun modifyViews(view: View, viewDataModifiers: Set<DataModifier>): Set<DataModifier>
   fun resetViews(view: View, initialDataModifiers: Set<DataModifier>)

--- a/screencaptor/src/main/res/values/ids.xml
+++ b/screencaptor/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <item type="id" name="random_id" />
+</resources>

--- a/screencaptor/src/test/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessorTest.kt
+++ b/screencaptor/src/test/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessorTest.kt
@@ -41,6 +41,11 @@ class DefaultViewDataProcessorTest {
   }
 
   @Test
+  fun modifyViews_notPresentIdDoesNotThrow() {
+    viewDataProcessor.modifyViews(sampleView, setOf(TextViewDataModifier(R.id.random_id, "hidden")))
+  }
+
+  @Test
   fun resetViews() {
     val initialState = viewDataProcessor.modifyViews(sampleView, setOf(
       TextViewDataModifier(R.id.textView, "hidden"),


### PR DESCRIPTION
Since the ViewDataProcessor is a global setting, we need to handle cases where the ids are not found in the current view that is displayed.