### PR TITLE
Post screenshot to the handler to make sure the view updates are finished before taking the screenshot

### DIFF
--- a/screencaptor/src/main/java/com/wealthfront/screencaptor/ScreenCaptor.kt
+++ b/screencaptor/src/main/java/com/wealthfront/screencaptor/ScreenCaptor.kt
@@ -102,25 +102,26 @@ object ScreenCaptor {
       Log.d(SCREENSHOT, "Disabling views: $viewIdsToExclude")
       val initialStateOfViews = ViewVisibilityModifier.hideViews(view, viewIdsToExclude)
       val initialDataOfViews = dataProcessor.modifyViews(view, viewModifiers)
-      view.requestLayout()
 
-      Log.d(SCREENSHOT, "Taking screenshot for '$screenshotFile'")
-      val bitmap = Bitmap.createBitmap(view.width, view.height, ARGB_8888)
-      val canvas = Canvas(bitmap)
-      view.draw(canvas)
+      view.post {
+        Log.d(SCREENSHOT, "Taking screenshot for '$screenshotFile'")
+        val bitmap = Bitmap.createBitmap(view.width, view.height, ARGB_8888)
+        val canvas = Canvas(bitmap)
+        view.draw(canvas)
 
-      if (!File(screenshotDirectory).exists()) {
-        Log.d(SCREENSHOT, "Creating directory $screenshotDirectory since it does not exist")
-        File(screenshotDirectory).mkdirs()
+        if (!File(screenshotDirectory).exists()) {
+          Log.d(SCREENSHOT, "Creating directory $screenshotDirectory since it does not exist")
+          File(screenshotDirectory).mkdirs()
+        }
+
+        Log.d(SCREENSHOT, "Writing to disk for '$screenshotFile'")
+        bitmap.compress(screenshotFormat.compression, screenshotQuality.value, FileOutputStream(screenshotFile))
+        Log.d(SCREENSHOT, "Successfully wrote to disk for '$screenshotFile'")
+
+        Log.d(SCREENSHOT, "Enabling views: $viewIdsToExclude")
+        ViewVisibilityModifier.showViews(view, viewIdsToExclude, initialStateOfViews)
+        dataProcessor.resetViews(view, initialDataOfViews)
       }
-
-      Log.d(SCREENSHOT, "Writing to disk for '$screenshotFile'")
-      bitmap.compress(screenshotFormat.compression, screenshotQuality.value, FileOutputStream(screenshotFile))
-      Log.d(SCREENSHOT, "Successfully wrote to disk for '$screenshotFile'")
-
-      Log.d(SCREENSHOT, "Enabling views: $viewIdsToExclude")
-      ViewVisibilityModifier.showViews(view, viewIdsToExclude, initialStateOfViews)
-      dataProcessor.resetViews(view, initialDataOfViews)
     }
   }
 }


### PR DESCRIPTION
This is kinda hacky but this allows us to wait for the view resizing changes to happen before retaking the screenshot. 

For more context, we added the ability to change the data on the fly before and screenshot is taken and since the data for textviews can be changed now, the views need to be resized and laid out. And this usually happens by the view being marked as dirty and then updating the actual view at a later time with the handler. This just makes sure we post a message later to the message queue and ensure that the view is resized and updated before the screenshot is taken.