### PR TITLE
Fix: Queue draw call so it takes place after view modifications are applied

### DIFF
--- a/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/SampleActivity.kt
+++ b/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/SampleActivity.kt
@@ -2,11 +2,16 @@ package com.wealthfront.screencaptor
 
 import android.app.Activity
 import android.os.Bundle
+import android.widget.Button
+import android.widget.Toast
 
 class SampleActivity : Activity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.screenshot_test)
+    findViewById<Button>(R.id.showToast).setOnClickListener {
+      Toast.makeText(this, "I am a Toast message", Toast.LENGTH_LONG).show()
+    }
   }
 }

--- a/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
+++ b/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
@@ -7,6 +7,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
+import com.wealthfront.screencaptor.views.modifier.TextViewDataModifier
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -27,7 +28,7 @@ class ScreenshotTest {
 
   @After
   fun cleanUpScreenshots() {
-    File(screenShotDirectory).deleteRecursively()
+//    File(screenShotDirectory).deleteRecursively()
   }
 
   @Test
@@ -73,6 +74,22 @@ class ScreenshotTest {
       assertTrue(File(screenShotDirectory).exists())
       assertTrue(File(screenShotDirectory).listFiles()!!.isNotEmpty())
       assertTrue(File(screenShotDirectory).listFiles()!!.find { it.name.contains("screenshot_activity") }!!.exists())
+    }
+  }
+
+  @Test
+  fun takeScreenshot_modify() {
+    ScreenCaptor.takeScreenshot(
+      activity = activityTestRule.activity,
+      screenshotName = "screenshot_change_text",
+      viewModifiers = setOf(TextViewDataModifier(R.id.textView, "Some shorter sample data"))
+    )
+
+    Espresso.onIdle {
+      assertTrue(File(screenShotDirectory).exists())
+      assertTrue(File(screenShotDirectory).listFiles()!!.isNotEmpty())
+      assertTrue(File(screenShotDirectory).listFiles()!!.find { it.name.contains("screenshot_change_text") }!!.exists()
+      )
     }
   }
 

--- a/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
+++ b/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
@@ -28,7 +28,7 @@ class ScreenshotTest {
 
   @After
   fun cleanUpScreenshots() {
-//    File(screenShotDirectory).deleteRecursively()
+    File(screenShotDirectory).deleteRecursively()
   }
 
   @Test

--- a/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
+++ b/screencaptor/src/androidTest/java/com/wealthfront/screencaptor/ScreenshotTest.kt
@@ -4,6 +4,9 @@ import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.widget.ImageView
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
@@ -65,6 +68,8 @@ class ScreenshotTest {
 
   @Test
   fun takeScreenshot_activity() {
+    onView(withId(R.id.showToast)).perform(click())
+
     ScreenCaptor.takeScreenshot(
       activity = activityTestRule.activity,
       screenshotName = "screenshot_activity"

--- a/screencaptor/src/main/res/layout/screenshot_test.xml
+++ b/screencaptor/src/main/res/layout/screenshot_test.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    tools:ignore="HardcodedText"
     >
 
   <androidx.core.widget.NestedScrollView
@@ -38,7 +39,7 @@
           android:inputType="text"
           android:textColorHint="#FFFFFF"
           android:gravity="center"
-          tools:ignore="Autofill,HardcodedText,LabelFor"
+          tools:ignore="Autofill,LabelFor"
           />
 
       <TextView
@@ -46,7 +47,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:text="Some sample data which is really long, so long that it wraps to another line and maybe even three lines"
-          tools:ignore="HardcodedText"
           />
 
       <ScrollView
@@ -54,6 +54,12 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           />
+
+      <Button
+          android:id="@+id/showToast"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Show toast"/>
 
     </LinearLayout>
 

--- a/screencaptor/src/main/res/layout/screenshot_test.xml
+++ b/screencaptor/src/main/res/layout/screenshot_test.xml
@@ -45,7 +45,7 @@
           android:id="@+id/textView"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:text="Sample data"
+          android:text="Some sample data which is really long, so long that it wraps to another line and maybe even three lines"
           tools:ignore="HardcodedText"
           />
 

--- a/screencaptor/src/test/java/com/wealthfront/screencaptor/views/extensions/ViewExtensionsTest.kt
+++ b/screencaptor/src/test/java/com/wealthfront/screencaptor/views/extensions/ViewExtensionsTest.kt
@@ -21,7 +21,7 @@ class ViewExtensionsTest {
   @Test
   fun getAllChildren() {
     val children = sampleView.getAllChildren()
-    assertThat(children.count()).isEqualTo(7)
+    assertThat(children.count()).isEqualTo(8)
     assertThat(children[0]).isInstanceOf(LinearLayout::class.java)
     assertThat(children[1]).isInstanceOf(NestedScrollView::class.java)
     assertThat(children[2]).isInstanceOf(LinearLayout::class.java)

--- a/screencaptor/src/test/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessorTest.kt
+++ b/screencaptor/src/test/java/com/wealthfront/screencaptor/views/modifier/DefaultViewDataProcessorTest.kt
@@ -28,7 +28,7 @@ class DefaultViewDataProcessorTest {
 
   @Test
   fun modifyViews() {
-    assertThat(sampleView.findViewById<TextView>(R.id.textView).text).isEqualTo("Sample data")
+    assertThat(sampleView.findViewById<TextView>(R.id.textView).text).isEqualTo("Some sample data which is really long, so long that it wraps to another line and maybe even three lines")
     sampleView.findViewById<ImageView>(R.id.wealthfrontIcon).drawable.pixelsEqualTo(application.getDrawable(R.drawable.wf_logo))
 
     viewDataProcessor.modifyViews(sampleView, setOf(
@@ -57,7 +57,7 @@ class DefaultViewDataProcessorTest {
 
     viewDataProcessor.resetViews(sampleView, initialState)
 
-    assertThat(sampleView.findViewById<TextView>(R.id.textView).text).isEqualTo("Sample data")
+    assertThat(sampleView.findViewById<TextView>(R.id.textView).text).isEqualTo("Some sample data which is really long, so long that it wraps to another line and maybe even three lines")
     sampleView.findViewById<ImageView>(R.id.wealthfrontIcon).drawable.pixelsEqualTo(application.getDrawable(R.drawable.wf_logo))
   }
 }


### PR DESCRIPTION
restore functionality of: https://github.com/wealthfront/ScreenCaptor/pull/8