### PR TITLE
Update publish scripts

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -79,7 +79,6 @@ afterEvaluate { project ->
     }
   }
 
-
   publishing.publications.all { publication ->
     publication.groupId = GROUP
     publication.version = VERSION_NAME
@@ -88,8 +87,6 @@ afterEvaluate { project ->
   }
 
   signing {
-    publishing.publications.all { publication ->
-      sign publication
-    }
+    sign publishing.publications
   }
 }

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -79,27 +79,10 @@ afterEvaluate { project ->
     }
   }
 
-  if (project.getPlugins().hasPlugin('com.android.application') ||
-          project.getPlugins().hasPlugin('com.android.library')) {
-
-    task androidSourcesJar(type: Jar) {
-      archiveClassifier = 'sources'
-      from android.sourceSets.main.java.source
-    }
-  }
-
-  artifacts {
-    if (project.getPlugins().hasPlugin('com.android.application') ||
-            project.getPlugins().hasPlugin('com.android.library')) {
-      archives androidSourcesJar
-    }
-  }
 
   publishing.publications.all { publication ->
     publication.groupId = GROUP
     publication.version = VERSION_NAME
-
-    publication.artifact androidSourcesJar
 
     configurePom(publication.pom)
   }

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -87,6 +87,8 @@ afterEvaluate { project ->
   }
 
   signing {
-    sign publishing.publications
+    publishing.publications.all { publication ->
+      sign publication
+    }
   }
 }

--- a/screencaptor-sample-tests/build.gradle.kts
+++ b/screencaptor-sample-tests/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
   implementation(libs.androidx.test.rules)
   implementation(libs.androidx.test.junit)
 
-  implementation(enforcedPlatform(libs.compose.bom))
+  implementation(platform(libs.compose.bom))
   implementation(libs.compose.foundation)
   implementation(libs.compose.ui)
   implementation(libs.compose.tooling)

--- a/screencaptor-sample/build.gradle.kts
+++ b/screencaptor-sample/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation(libs.appcompat)
   testImplementation(project(":internal-test-support"))
 
-  implementation(enforcedPlatform(libs.compose.bom))
+  implementation(platform(libs.compose.bom))
   implementation(libs.compose.foundation)
   implementation(libs.compose.ui)
   implementation(libs.compose.tooling)

--- a/screencaptor/build.gradle.kts
+++ b/screencaptor/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     testImplementation(libs.androidx.test.junit)
     testImplementation(libs.compose.junit4)
 
-    implementation(enforcedPlatform(libs.compose.bom))
+    implementation(platform(libs.compose.bom))
     implementation(libs.compose.foundation)
     implementation(libs.compose.ui)
     implementation(libs.compose.tooling)

--- a/screencaptor/build.gradle.kts
+++ b/screencaptor/build.gradle.kts
@@ -19,6 +19,11 @@ android {
         compose = true
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
best practice: avoid enforcedPlatform as this library will be pulled into various codebases
configure androidSources publication via AGP